### PR TITLE
Use `assert` as its introduced in the text

### DIFF
--- a/questions.json
+++ b/questions.json
@@ -194,9 +194,9 @@
     {
         "topic": "Assertions",
         "path": "assertions",
-        "question": "`Assertions` are generally used to check that certain requirements \non or between features and dependencies hold. They look like this:\n\n    assert e1; e2\n    \nwhere `e1` is an expression that should evaluate to a `boolean` value. \nIf it evaluates to `true`, `e2` is returned; otherwise expression \nevaluation is aborted and a backtrace is printed.\n\n**Note:** that **->** is the **logical implication** Boolean operation.\n\n See also <https://nixos.org/manual/nix/stable/language/constructs#assertions>.",
-        "code": "with import <nixpkgs> {};\nlet\n  func = x: y: assert (x==2) || abort \"x has to be 2 or it won't work!\"; x + y;\n  n = \"-5\"; # only modify this line\nin\n\nassert (lib.isInt n) || abort \"Type error since supplied argument is no int!\";\n\nrec {\n  ex00 = func (n+3) 3;\n}",
-        "solution": "with import <nixpkgs> {};\nlet\n  func = x: y: assert (x==2) || abort \"x has to be 2 or it won't work!\"; x + y;\n  n = -1;\nin\n\nassert (lib.isInt n) || abort \"Type error since supplied argument is no int!\";\nassert (lib.isInt n) -> (n > -5);\n\nrec {\n  ex00 = func (n+3) 3;\n}",
+        "question": "`Assertions` are generally used to check that certain requirements \non or between features and dependencies hold. They look like this:\n\n    assert e1; e2\n    \nwhere `e1` is an expression that should evaluate to a `boolean` value. \nIf it evaluates to `true`, `e2` is returned; otherwise expression \nevaluation is aborted and a backtrace is printed.\n\nSee also <https://nixos.org/manual/nix/stable/language/constructs#assertions>.",
+        "code": "with import <nixpkgs> {};\nlet\n  func = x: y: assert x==2; x + y;\n  n = \"-5\"; # only modify this line\nin\n\nassert (lib.isInt n);\n\nrec {\n  ex00 = func (n+3) 3;\n}",
+        "solution": "with import <nixpkgs> {};\nlet\n  func = x: y: assert x==2; x + y;\n  n = -1;\nin\n\nassert (lib.isInt n);\n\nrec {\n  ex00 = func (n+3) 3;\n}",
         "youtube": "https://www.youtube.com/watch?v=g-qDaCr2rwQ&list=PLMr2KA8WWojv-4cgqIiVebml0FrMl8N_-"
     },
     {


### PR DESCRIPTION
Instead of using assert to evaluate an `abort`, use it as it's described in the problem text and linked manual.

fixes #37